### PR TITLE
Document a few macros all hardwares are required to implement

### DIFF
--- a/src/Kaleidoscope-Hardware.h
+++ b/src/Kaleidoscope-Hardware.h
@@ -23,6 +23,17 @@
 
 #pragma once
 
+/* All hardware libraries must define the following macros:
+ * KALEIDOSCOPE_HARDWARE_H - filename of the file Kaleidoscope should include for
+ *     your hardware
+ *   Should contain, at minimum, declarations of everything listed in this file
+ *     as required
+ * ROWS - the number of rows on the keyboard
+ * COLS - the number of columns on the keyboard
+ * LED_COUNT - the total number of LEDs on the keyboard (can be 0)
+ * CRGB(r,g,b) - explained below
+ */
+
 /**
  * Forward declaration of the cRGB structure.
  *


### PR DESCRIPTION
Noticed that this part of the hardware API wasn't documented here.