### PR TITLE
Fix a stupid mistake I made in commit 1561a5d

### DIFF
--- a/src/Kaleidoscope-Hardware.h
+++ b/src/Kaleidoscope-Hardware.h
@@ -24,10 +24,8 @@
 #pragma once
 
 /* All hardware libraries must define the following macros:
- * KALEIDOSCOPE_HARDWARE_H - filename of the file Kaleidoscope should include for
- *     your hardware
- *   Should contain, at minimum, declarations of everything listed in this file
- *     as required
+ * HARDWARE_IMPLEMENTATION - the name of your public object conforming to
+ *   the 'class Hardware' interface below.
  * ROWS - the number of rows on the keyboard
  * COLS - the number of columns on the keyboard
  * LED_COUNT - the total number of LEDs on the keyboard (can be 0)


### PR DESCRIPTION
Sorry about this.  Should have double checked it before creating the PR.

`KALEIDOSCOPE_HARDWARE_H` isn't directly defined in the hardware definition (it can't be) - instead you configure the build system to pass `-DKALEIDOSCOPE_HARDWARE_H=foo` for the appropriate value of `foo`.

But, hardware definitions are responsible for `HARDWARE_IMPLEMENTATION` as now documented in Kaleidoscope-Hardware.h.

Somehow I mixed up these two things in my head.